### PR TITLE
Emisweb 134: Fix bulk import/export: unlock marks sheet cells and close modal after upload

### DIFF
--- a/src/components/bulkImport/BulkMarksUpload.tsx
+++ b/src/components/bulkImport/BulkMarksUpload.tsx
@@ -112,7 +112,7 @@ export const BulkMarksUpload = ({ setOpen, isOpen, forUpdate }: BulkMarksUploadP
     }
     return (
         <>
-            { (!isProcessing && !summaryOpen) &&
+            {(!isProcessing && !summaryOpen) &&
                 // <MuiThemeProvider theme={theme}>
                 //     <DropzoneDialog
                 //         dialogTitle={"Bulk Marks Upload"}
@@ -142,7 +142,7 @@ export const BulkMarksUpload = ({ setOpen, isOpen, forUpdate }: BulkMarksUploadP
                 //     />
                 // </MuiThemeProvider>
 
-                <DropZone onSave={onSave}/>
+                <DropZone onSave={onSave} setOpenDropZone={setOpen}/>
             }
             {(summaryOpen) &&
                 <Modal large position={"middle"} className={styles.modalContainer}>
@@ -151,6 +151,7 @@ export const BulkMarksUpload = ({ setOpen, isOpen, forUpdate }: BulkMarksUploadP
                         {isProcessing
                             ? <CenteredContent className="p-5"><CircularLoader /></CenteredContent>
                             : <ModalSummaryContent
+                                setOpenDropZone={setOpen}
                                 setOpen={setSummaryOpen}
                                 summaryData={
                                     {

--- a/src/components/bulkImport/ModalSummaryContent.tsx
+++ b/src/components/bulkImport/ModalSummaryContent.tsx
@@ -21,6 +21,7 @@ import { ProgressState } from "../../schema/linearProgress";
 import IteractiveProgress from "../modal/components/importProgress";
 
 interface ModalContentProps {
+    setOpenDropZone: (value: boolean) => void
     setOpen: (value: boolean) => void
     summaryData: any
     summaryDetails?: React.ReactElement
@@ -28,6 +29,7 @@ interface ModalContentProps {
 
 const ModalSummaryContent = (props: ModalContentProps): React.ReactElement => {
     const {
+        setOpenDropZone,
         setOpen,
         summaryData,
         summaryDetails
@@ -143,6 +145,7 @@ const ModalSummaryContent = (props: ModalContentProps): React.ReactElement => {
             disabled: loading,
             loading: false,
             onClick: () => {
+                setOpenDropZone(false)
                 setOpen(false)
             }
         }

--- a/src/components/dropzone/DropZone.tsx
+++ b/src/components/dropzone/DropZone.tsx
@@ -2,14 +2,19 @@ import "./dropzone.css"
 import Lottie from "lottie-react";
 import { Form } from "react-final-form";
 import React, { useState, useRef, useEffect } from "react";
-import  uploadcloud  from "../../assets/images/bulkImport/uploadcloud.json"
+import uploadcloud from "../../assets/images/bulkImport/uploadcloud.json"
 import Excel from "../../assets/images/bulkImport/excel.svg"
 import { ModalActions, Button, ButtonStrip } from "@dhis2/ui";
 import FileInput from "../genericFields/fields/FileInput";
 import classNames from "classnames";
 
-function DropZone(props: any) {
-    const { onSave } = props;
+interface DropZonepProps {
+    setOpenDropZone: (value: boolean) => void
+    onSave: (value: any) => void
+}
+
+function DropZone(props: DropZonepProps) {
+    const { onSave, setOpenDropZone } = props;
     const [uploadedFile, setUploadedFile] = useState<any>('');
     const formRef: React.MutableRefObject<FormApi<IForm, Partial<IForm>>> = useRef(null);
     const inputFiles = document.querySelectorAll(".dropzone_area input[type='file']");
@@ -36,6 +41,7 @@ function DropZone(props: any) {
 
     function hanldeCancel() {
         setUploadedFile(undefined);
+        setOpenDropZone(false);
     }
 
     const modalActions = [
@@ -53,7 +59,7 @@ function DropZone(props: any) {
                 >
                     <div className={classNames("dropzone_area", uploadedFile && "dropzone_area_filled_bg")}>
                         <div className="file_upload_icon">
-                            {uploadedFile ? <img src={Excel} className="mb-5 mt-5"/> : <Lottie  animationData={uploadcloud} loop={true} />}
+                            {uploadedFile ? <img src={Excel} className="mb-5 mt-5" /> : <Lottie animationData={uploadcloud} loop={true} />}
                         </div>
                         <FileInput name="uploaded-file" setUploadedFile={setUploadedFile} />
                         <h4 className="mb-3 file-info">Drag & drop files or browse</h4>

--- a/src/hooks/exportTemplate/getHeaderBgColor.ts
+++ b/src/hooks/exportTemplate/getHeaderBgColor.ts
@@ -12,9 +12,11 @@ export const getHeaderBgColor = (metadataType: string) => {
       return "D9EAD3";
 
     case VariablesTypes.DataElement:
+    case VariablesTypes.Performance:
     case SectionVariablesTypes.SocioEconomics:
       return "FFF2CC";
+
     default:
-      return "FFFFFF";
+      return "FFF2CC";
   }
 };

--- a/src/hooks/exportTemplate/useExportTemplate.ts
+++ b/src/hooks/exportTemplate/useExportTemplate.ts
@@ -174,7 +174,8 @@ export default function useExportTemplate() {
                     optionSetId: dxCurr.dataElement?.optionSet?.id || null,
                     required: dxCurr?.compulsory || false,
                     metadataType: VariablesTypes.DataElement,
-                    sectionDataType: selectedTerm.label
+                    sectionDataType: selectedTerm.label,
+                    type: VariablesTypes.Performance
                   })
                   return dxPrev
                 },
@@ -537,12 +538,9 @@ export default function useExportTemplate() {
         // Validate that stage cells (number fields) are between 0 and 100
         headers.forEach((header: any, idx: number) => {
           const cell = row.getCell(idx + 1)
-
           // Apply validation for stage cells (only allow numbers between 0 and 100)
-          if (
-            header.metadataType === VariablesTypes.DataElement &&
-            header.valueType === "NUMBER"
-          ) {
+          /** Use VariablesTypes.Performance to not lock cells */
+          if (header.type === VariablesTypes.Performance) {
             if (!header.key.includes(registration.programStage)) {
               cell.protection = { locked: false }
             }


### PR DESCRIPTION
The issue was caused because the condition to unlock sheet cells was weak, as it was using a wrong input field type (NUMBER instead of INTEGER_ZERO_OR_POSITIVE). And as expected the marks cells were locked. 
To solve this issue the comparison is being made by VariableType. 